### PR TITLE
Add from-codepoints function

### DIFF
--- a/test/test.janet
+++ b/test/test.janet
@@ -40,3 +40,6 @@
 # Basic sanity test.
 (assert (= (utf8/normalize "abc😀") "abc😀"))
 
+# Test from- and to-codepoints
+(def s "ěščřžýáíé")
+(assert (= s (utf8/from-codepoints (utf8/to-codepoints s))))

--- a/test/test.janet
+++ b/test/test.janet
@@ -43,3 +43,6 @@
 # Test from- and to-codepoints
 (def s "ěščřžýáíé")
 (assert (= s (utf8/from-codepoints (utf8/to-codepoints s))))
+
+(try (utf8/from-codepoints [[]])
+  ([e] (assert (= e "0th member of the sequence is not janet number"))))

--- a/utf8.c
+++ b/utf8.c
@@ -113,7 +113,7 @@ static Janet jutf8_from_codepoints(int argc, Janet *argv) {
 
   }
   Janet v = janet_stringv(s, bytes_converted);
-  if (l > alloca_limit) {
+  if (sl > alloca_limit) {
     janet_sfree(s);
   }
   return v;

--- a/utf8.c
+++ b/utf8.c
@@ -98,11 +98,9 @@ static Janet jutf8_from_codepoints(int argc, Janet *argv) {
   utf8proc_uint8_t *s = sl > alloca_limit ? janet_smalloc(sl) : alloca(sl);
   for (utf8proc_ssize_t i = 0; i < l; i++) {
     utf8proc_uint8_t r[4];
-    utf8proc_int32_t cp;
-    if (janet_checktype(c[i], JANET_NUMBER)) 
-      cp = janet_unwrap_integer(c[i]);
-    else 
+    if (!janet_checktype(c[i], JANET_NUMBER)) 
       janet_panicf("%ith member of the sequence is not janet number", i);
+    utf8proc_int32_t cp = janet_unwrap_integer(c[i]);
     utf8proc_ssize_t sz = utf8proc_encode_char(cp, r);
     if (sz == 0)
       janet_panicf("%v is not a valid unicode sequence: %s", argv[0],

--- a/utf8.c
+++ b/utf8.c
@@ -95,10 +95,14 @@ static Janet jutf8_from_codepoints(int argc, Janet *argv) {
   utf8proc_ssize_t sl = l * 4;
   utf8proc_ssize_t bytes_converted = 0;
   const utf8proc_ssize_t alloca_limit = 64;
-  utf8proc_uint8_t *s = l > alloca_limit ? janet_smalloc(l) : alloca(l);
+  utf8proc_uint8_t *s = sl > alloca_limit ? janet_smalloc(sl) : alloca(sl);
   for (utf8proc_ssize_t i = 0; i < l; i++) {
     utf8proc_uint8_t r[4];
-    utf8proc_int32_t cp = janet_unwrap_integer(c[i]);
+    utf8proc_int32_t cp;
+    if (janet_checktype(c[i], JANET_NUMBER)) 
+      cp = janet_unwrap_integer(c[i]);
+    else 
+      janet_panicf("%ith member of the sequence is not janet number", i);
     utf8proc_ssize_t sz = utf8proc_encode_char(cp, r);
     if (sz == 0)
       janet_panicf("%v is not a valid unicode sequence: %s", argv[0],


### PR DESCRIPTION
As discussed in #1 and on Matrix, I have added the `from-codepoints` function, which will convert any Janet sequence of numbers to utf8 string.